### PR TITLE
Adding support for mapping to an interface.

### DIFF
--- a/src/Dapper.Mapper/MappingCache.cs
+++ b/src/Dapper.Mapper/MappingCache.cs
@@ -17,7 +17,7 @@ namespace Dapper.Mapper
                     Parameter = parameter,
                     Property = parameter.Type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
                         .Where(property => property.CanWrite && !property.GetIndexParameters().Any())
-                        .Where(property => property.PropertyType == sourceExpression.Type || IsSubclassOf(sourceExpression.Type, property.PropertyType))
+                        .Where(property => property.PropertyType == sourceExpression.Type || IsSubclassOf(sourceExpression.Type, property.PropertyType) || property.PropertyType.IsAssignableFrom(sourceExpression.Type))
                         .FirstOrDefault()
                 })
                 .Where(parameter => parameter.Property != null)

--- a/test/Dapper.Mapper.Tests/MappingCacheTests.cs
+++ b/test/Dapper.Mapper.Tests/MappingCacheTests.cs
@@ -227,6 +227,22 @@ namespace Dapper.Mapper.Tests
             // Assert
             Assert.Null(result.Second);
         }
+
+        [Fact]
+        public void MappingCache8()
+        {
+            // Arrange
+            var withInterface = new Eighth();
+            var test = new Test();
+
+            var map = MappingCache<Eighth, Test>.Map;
+
+            // Act
+            var result = map(withInterface, test);
+
+            // Assert
+            Assert.NotNull(result.Test);
+        }
     }
 
     public class First
@@ -266,4 +282,13 @@ namespace Dapper.Mapper.Tests
     public class Seventh
     {
     }
+
+    public class Eighth
+    {
+        public ITest Test { get; set; }
+    }
+
+    public interface ITest { }
+
+    public class Test : ITest { }
 }


### PR DESCRIPTION
Allow the use of mapping to properties with interface types.  In the mapping cache GetSetExpression, check the property type is assignable from the source type.